### PR TITLE
Adding instructions for Neovim in tmux to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,17 @@ set background=dark " for the dark version
 " set background=light " for the light version
 colorscheme one
 ```
+### Tmux support
+To get true color working in tmux, ensure that the `$TERM` environment variable is set to `xterm-256color`. Inside the `.tmux.conf` file we need to override this terminal and also set the default terminal as 256 color.
 
+```
+# Add truecolor support
+set-option -ga terminal-overrides ",xterm-256color:Tc"
+# Default terminal is 256 colors
+set -g default-terminal "screen-256color"
+```
+
+Note that this only works for Neovim (tested on 0.1.5), Vim (7.5.2334) doesn't play nice for some reason. See [blog post Anton Kalyaev](http://homeonrails.com/2016/05/truecolor-in-gnome-terminal-tmux-and-neovim/) for more details on setting up tmux.
 
 I've tested the following setup on a Mac:
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ set-option -ga terminal-overrides ",xterm-256color:Tc"
 set -g default-terminal "screen-256color"
 ```
 
-Note that this only works for Neovim (tested on 0.1.5), Vim (7.5.2334) doesn't play nice for some reason. See [blog post Anton Kalyaev](http://homeonrails.com/2016/05/truecolor-in-gnome-terminal-tmux-and-neovim/) for more details on setting up tmux.
+Note that this only works for Neovim (tested on 0.1.5). For some reason Vim (7.5.2334) doesn't play nice. See [blog post by Anton Kalyaev](http://homeonrails.com/2016/05/truecolor-in-gnome-terminal-tmux-and-neovim/) for more details on setting up tmux.
 
 I've tested the following setup on a Mac:
 

--- a/colors/one.vim
+++ b/colors/one.vim
@@ -690,6 +690,5 @@ if has('gui_running') || &t_Co == 88 || &t_Co == 256
 
 endif
 "}}}
-  
 
 " vim: set fdl=0 fdm=marker:

--- a/colors/one.vim
+++ b/colors/one.vim
@@ -16,7 +16,7 @@ if !exists('g:one_allow_italics')
   let g:one_allow_italics = 0
 endif
 
-if has('gui_running') || &t_Co == 88 || &t_Co == 256
+if has('gui_running') || &t_Co == 8 || &t_Co == 256
   " functions
   " returns an approximate grey index for the given grey level
 

--- a/colors/one.vim
+++ b/colors/one.vim
@@ -690,5 +690,9 @@ if has('gui_running') || &t_Co == 8 || &t_Co == 256
 
 endif
 "}}}
+  
+endif
+"}}}
+
 
 " vim: set fdl=0 fdm=marker:

--- a/colors/one.vim
+++ b/colors/one.vim
@@ -691,8 +691,5 @@ if has('gui_running') || &t_Co == 88 || &t_Co == 256
 endif
 "}}}
   
-endif
-"}}}
-
 
 " vim: set fdl=0 fdm=marker:

--- a/colors/one.vim
+++ b/colors/one.vim
@@ -16,7 +16,7 @@ if !exists('g:one_allow_italics')
   let g:one_allow_italics = 0
 endif
 
-if has('gui_running') || &t_Co == 8 || &t_Co == 256
+if has('gui_running') || &t_Co == 88 || &t_Co == 256
   " functions
   " returns an approximate grey index for the given grey level
 


### PR DESCRIPTION
This is how I got neovim working. Vim still won't load the colorscheme while running in tmux, but fine in iTerm.

Happy for you to edit/incorporate how you see fit, not exactly a solution for everyone. Also ignore all the commits, I was having some issues.