### PR TITLE
Make Title easily legible when a tab is selected

### DIFF
--- a/colors/one.vim
+++ b/colors/one.vim
@@ -691,8 +691,7 @@ if has('gui_running') || &t_Co == 88 || &t_Co == 256
   call <sid>X('zshVariableDef',  s:hue_6,     '', '')
   " }}}
 
-" Rust highlighting -------------------------------------------------------{{{
-
+  " Rust highlighting -------------------------------------------------------{{{
   call <sid>X('rustExternCrate',          s:hue_5,    '', 'bold')
   call <sid>X('rustIdentifier',           s:hue_2,    '', '')
   call <sid>X('rustDeriveTrait',          s:hue_4,    '', '')
@@ -703,7 +702,7 @@ if has('gui_running') || &t_Co == 88 || &t_Co == 256
   call <sid>X('rustCommentBlock',         s:mono_3,    '', '')
   call <sid>X('rustCommentBlockDoc',      s:mono_3,    '', '')
   call <sid>X('rustCommentBlockDocError', s:mono_3,    '', '')
-" }}}
+  " }}}
 
   " man highlighting --------------------------------------------------------{{{
   hi link manTitle String

--- a/colors/one.vim
+++ b/colors/one.vim
@@ -707,6 +707,7 @@ if has('gui_running') || &t_Co == 88 || &t_Co == 256
 
   " man highlighting --------------------------------------------------------{{{
   hi link manTitle String
+  call <sid>X('manFooter', s:mono_3, '', '')
   " }}}
 
   " Delete functions =========================================================={{{

--- a/colors/one.vim
+++ b/colors/one.vim
@@ -512,6 +512,7 @@ if has('gui_running') || &t_Co == 88 || &t_Co == 256
   call <sid>X('htmlTagN',           s:hue_5,  '', '')
   call <sid>X('htmlSpecialTagName', s:hue_5,  '', '')
   call <sid>X('htmlTag',            s:mono_3, '', '')
+  hi link htmlH1 String
 
   call <sid>X('MatchTag',           s:syntax_accent, s:visual_grey, 'bold')
   " }}}
@@ -703,6 +704,10 @@ if has('gui_running') || &t_Co == 88 || &t_Co == 256
   call <sid>X('rustCommentBlockDoc',      s:mono_3,    '', '')
   call <sid>X('rustCommentBlockDocError', s:mono_3,    '', '')
 " }}}
+
+  " man highlighting --------------------------------------------------------{{{
+  hi link manTitle String
+  " }}}
 
   " Delete functions =========================================================={{{
   delf <SID>X

--- a/colors/one.vim
+++ b/colors/one.vim
@@ -340,7 +340,7 @@ if has('gui_running') || &t_Co == 88 || &t_Co == 256
   call <sid>X('TabLine',      s:mono_1,        s:syntax_bg,      '')
   call <sid>X('TabLineFill',  s:mono_3,        s:visual_grey,    'none')
   call <sid>X('TabLineSel',   s:syntax_bg,     s:hue_2,          '')
-  call <sid>X('Title',        s:hue_4,         '',               'none')
+  call <sid>X('Title',        s:mono_3,        '',               'none')
   call <sid>X('Visual',       '',              s:visual_grey,    '')
   call <sid>X('VisualNOS',    '',              s:visual_grey,    '')
   call <sid>X('WarningMsg',   s:hue_5,         '',               '')


### PR DESCRIPTION
`hue_2` (bg) and `hue_4` (fg) don’t mix well neither in `background=dark` nor in `background=light`.

Current situation (selected; look how unpleasant the `2` at the top-left corner looks):
![one-orig-selected](https://cloud.githubusercontent.com/assets/3979978/21772788/51410b22-d695-11e6-886c-a89970577e21.png)

Current situation (not selected):
![one-orig-notselected](https://cloud.githubusercontent.com/assets/3979978/21772766/424b7ec2-d695-11e6-811e-3cd99fee53e9.png)

Proposed solution (selected):
![one-new-selected](https://cloud.githubusercontent.com/assets/3979978/21772769/43227f9e-d695-11e6-8f27-83786632110e.png)

Proposed solution (not selected):
![one-new-notselected](https://cloud.githubusercontent.com/assets/3979978/21772767/42ca635e-d695-11e6-949f-37a90ca4dc71.png)