### PR TITLE
Make preview colors more closely match Atom autocompletion

### DIFF
--- a/colors/one.vim
+++ b/colors/one.vim
@@ -252,7 +252,6 @@ if has('gui_running') || &t_Co == 88 || &t_Co == 256
     let s:mono_2 = '828997'
     let s:mono_3 = '5c6370'
 
-
     let s:hue_1  = '56b6c2' " cyan
     let s:hue_2  = '61afef' " blue
     let s:hue_3  = 'c678dd' " purple
@@ -328,8 +327,8 @@ if has('gui_running') || &t_Co == 88 || &t_Co == 256
   call <sid>X('ModeMsg',      s:syntax_fg,     '',               '')
   call <sid>X('MoreMsg',      s:syntax_fg,     '',               '')
   call <sid>X('NonText',      s:mono_3,        '',               'none')
-  call <sid>X('PMenu',        '',              s:visual_grey,    '')
-  call <sid>X('PMenuSel',     '',              s:syntax_bg,      '')
+  call <sid>X('PMenu',        '',              s:syntax_bg,      '')
+  call <sid>X('PMenuSel',     '',              s:visual_grey,    '')
   call <sid>X('PMenuSbar',    '',              s:syntax_bg,      '')
   call <sid>X('PMenuThumb',   '',              s:mono_1,         '')
   call <sid>X('Question',     s:hue_2,         '',               '')


### PR DESCRIPTION
Atom: 

![screenshot 2017-01-13 10 28 08](https://cloud.githubusercontent.com/assets/319471/21936233/75b39e2a-d97e-11e6-928c-89ea684c0c41.png)

Current vim-one (selected and not selected are reversed dark/light, exact same color as BG):
![screenshot 2017-01-13 10 31 31](https://cloud.githubusercontent.com/assets/319471/21936245/80f9075c-d97e-11e6-97d6-e3a59f8f6ed6.png)

After change:
![screenshot 2017-01-13 10 54 32](https://cloud.githubusercontent.com/assets/319471/21936297/ae57e86c-d97e-11e6-99d3-110c8303e12d.png)

