### PR TITLE
Elixir support more consistent with Atom

### DIFF
--- a/colors/one.vim
+++ b/colors/one.vim
@@ -519,6 +519,8 @@ if has('gui_running') || &t_Co == 88 || &t_Co == 256
   call <sid>X('elixirAtom',              s:hue_1,   '', '')
   call <sid>X('elixirBlockDefinition',   s:hue_3,   '', '')
   call <sid>X('elixirModuleDeclaration', s:hue_6,   '', '')
+  call <sid>X('elixirInclude',           s:hue_5,   '', '')
+  call <sid>X('elixirOperator',          s:hue_6,   '', '')
   " }}}
 
   " Git and git related plugins highlighting --------------------------------{{{


### PR DESCRIPTION
Changes the operator color and include keyword color to match Atom
DarkOne for Elixir.

## Before

<img width="1522" alt="image" src="https://user-images.githubusercontent.com/551858/34655104-4611edd6-f3ca-11e7-9c8f-79c5a62eeabe.png">


## After

<img width="1569" alt="image" src="https://user-images.githubusercontent.com/551858/34655087-1e682610-f3ca-11e7-8272-6beeb9aa94cd.png">
