### PR TITLE
Fix undefined variable error when t_Co=8

### DIFF
--- a/colors/one.vim
+++ b/colors/one.vim
@@ -28,7 +28,7 @@ if !exists('g:one_allow_italics')
   let g:one_allow_italics = 0
 endif
 
-if has('gui_running') || &t_Co == 88 || &t_Co == 256
+if has('gui_running') || has('termguicolors') || &t_Co == 88 || &t_Co == 256
   " functions
   " returns an approximate grey index for the given grey level
 

--- a/colors/one.vim
+++ b/colors/one.vim
@@ -837,7 +837,7 @@ function! one#highlight(group, fg, bg, attr)
 endfunction
 "}}}
 
-if s:dark
+if exists('s:dark') && s:dark
   set background=dark
 endif
 


### PR DESCRIPTION
Fixes #77

Also, allows user to enable true color behavior with `termguicolors` instead of `t_Co=256`. I _think_ this is the correct thing to do?

Please check my logic here, because I'm afraid my understanding of color stuff is limited.