### PR TITLE
Fix for NERDTree on Neovim 0.3+

### DIFF
--- a/colors/one.vim
+++ b/colors/one.vim
@@ -826,6 +826,10 @@ if has('gui_running') || has('termguicolors') || &t_Co == 88 || &t_Co == 256
   let g:terminal_color_7  = "#e3e5e9"
   let g:terminal_color_15 = "#e3e5e9"
   "}}}
+  
+  " Neovim NERDTree Background fix ------------------------------------------{{{
+  call <sid>X('NERDTreeFile', s:syntax_fg, '', '')
+  " }}}
 
   " ALE (Asynchronous Lint Engine) highlighting -----------------------------{{{
   call <sid>X('ALEWarningSign', s:hue_6_2, '', '')


### PR DESCRIPTION
Neovim 0.3 made some changes to the priorities of CursorLine, causing NERDTreeFiles not to be highlighted properly anymore with this theme. This Commit fixes the highlighting in Neovim without breaking anything for vim