### PR TITLE
Optimize loading time by reusing hi definitions with hi link

### DIFF
--- a/colors/one.vim
+++ b/colors/one.vim
@@ -353,6 +353,24 @@ if has('gui_running') || has('termguicolors') || &t_Co == 88 || &t_Co == 256
 
   " }}}
 
+  " Pre-define some hi groups -----------------------------------------------{{{
+  call <sid>X('OneMono1', s:mono_1, '', '')
+  call <sid>X('OneMono2', s:mono_2, '', '')
+  call <sid>X('OneMono3', s:mono_3, '', '')
+  call <sid>X('OneMono4', s:mono_4, '', '')
+
+  call <sid>X('OneHue1', s:hue_1, '', '')
+  call <sid>X('OneHue2', s:hue_2, '', '')
+  call <sid>X('OneHue3', s:hue_3, '', '')
+  call <sid>X('OneHue4', s:hue_4, '', '')
+  call <sid>X('OneHue5', s:hue_5, '', '')
+  call <sid>X('OneHue52', s:hue_5_2, '', '')
+  call <sid>X('OneHue6', s:hue_6, '', '')
+  call <sid>X('OneHue62', s:hue_6_2, '', '')
+
+  hi! link OneSyntaxFg OneMono1
+  " }}}
+
   " Vim editor color --------------------------------------------------------{{{
   call <sid>X('Normal',       s:syntax_fg,     s:syntax_bg,      '')
   call <sid>X('bold',         '',              '',               'bold')
@@ -362,76 +380,76 @@ if has('gui_running') || has('termguicolors') || &t_Co == 88 || &t_Co == 256
   call <sid>X('CursorIM',     '',              '',               '')
   call <sid>X('CursorColumn', '',              s:syntax_cursor,  '')
   call <sid>X('CursorLine',   '',              s:syntax_cursor,  'none')
-  call <sid>X('Directory',    s:hue_2,         '',               '')
+  hi! link Directory OneHue2
   call <sid>X('ErrorMsg',     s:hue_5,         s:syntax_bg,      'none')
   call <sid>X('VertSplit',    s:vertsplit,     '',               'none')
   call <sid>X('Folded',       s:syntax_bg,     s:syntax_fold_bg, 'none')
   call <sid>X('FoldColumn',   s:mono_3,        s:syntax_cursor,  '')
-  call <sid>X('IncSearch',    s:hue_6,         '',               '')
-  call <sid>X('LineNr',       s:mono_4,        '',               '')
+  hi! link IncSearch OneHue6
+  hi! link LineNr OneMono4
   call <sid>X('CursorLineNr', s:syntax_fg,     s:syntax_cursor,  'none')
   call <sid>X('MatchParen',   s:hue_5,         s:syntax_cursor,  'underline,bold')
   call <sid>X('Italic',       '',              '',               s:italic)
-  call <sid>X('ModeMsg',      s:syntax_fg,     '',               '')
-  call <sid>X('MoreMsg',      s:syntax_fg,     '',               '')
+  hi! link ModeMsg OneSyntaxFg
+  hi! link MoreMsg OneSyntaxFg
   call <sid>X('NonText',      s:mono_3,        '',               'none')
   call <sid>X('PMenu',        '',              s:pmenu,          '')
   call <sid>X('PMenuSel',     '',              s:mono_4,         '')
   call <sid>X('PMenuSbar',    '',              s:syntax_bg,      '')
   call <sid>X('PMenuThumb',   '',              s:mono_1,         '')
-  call <sid>X('Question',     s:hue_2,         '',               '')
+  hi! link Question OneHue2
   call <sid>X('Search',       s:syntax_bg,     s:hue_6_2,        '')
   call <sid>X('SpecialKey',   s:special_grey,  '',               'none')
   call <sid>X('Whitespace',   s:special_grey,  '',               'none')
   call <sid>X('StatusLine',   s:syntax_fg,     s:syntax_cursor,  'none')
-  call <sid>X('StatusLineNC', s:mono_3,        '',               '')
+  hi! link StatusLineNC OneMono3
   call <sid>X('TabLine',      s:mono_1,        s:syntax_bg,      '')
   call <sid>X('TabLineFill',  s:mono_3,        s:visual_grey,    'none')
   call <sid>X('TabLineSel',   s:syntax_bg,     s:hue_2,          '')
   call <sid>X('Title',        s:syntax_fg,     '',               'bold')
   call <sid>X('Visual',       '',              s:visual_grey,    '')
   call <sid>X('VisualNOS',    '',              s:visual_grey,    '')
-  call <sid>X('WarningMsg',   s:hue_5,         '',               '')
-  call <sid>X('TooLong',      s:hue_5,         '',               '')
+  hi! link WarningMsg OneHue5
+  hi! link TooLong OneHue5
   call <sid>X('WildMenu',     s:syntax_fg,     s:mono_3,         '')
   call <sid>X('SignColumn',   '',              s:syntax_bg,      '')
-  call <sid>X('Special',      s:hue_2,         '',               '')
+  hi! link Special OneHue2
   " }}}
 
   " Vim Help highlighting ---------------------------------------------------{{{
-  call <sid>X('helpCommand',      s:hue_6_2, '', '')
-  call <sid>X('helpExample',      s:hue_6_2, '', '')
+  hi! link helpCommand OneHue62
+  hi! link helpExample OneHue62
   call <sid>X('helpHeader',       s:mono_1,  '', 'bold')
-  call <sid>X('helpSectionDelim', s:mono_3,  '', '')
+  hi! link helpSectionDelim OneMono3
   " }}}
 
   " Standard syntax highlighting --------------------------------------------{{{
   call <sid>X('Comment',        s:mono_3,        '',          s:italic)
-  call <sid>X('Constant',       s:hue_4,         '',          '')
-  call <sid>X('String',         s:hue_4,         '',          '')
-  call <sid>X('Character',      s:hue_4,         '',          '')
-  call <sid>X('Number',         s:hue_6,         '',          '')
-  call <sid>X('Boolean',        s:hue_6,         '',          '')
-  call <sid>X('Float',          s:hue_6,         '',          '')
+  hi! link Constant OneHue4
+  hi! link String OneHue4
+  hi! link Character OneHue4
+  hi! link Number OneHue6
+  hi! link Boolean OneHue6
+  hi! link Float OneHue6
   call <sid>X('Identifier',     s:hue_5,         '',          'none')
-  call <sid>X('Function',       s:hue_2,         '',          '')
-  call <sid>X('Statement',      s:hue_3,         '',          'none')
-  call <sid>X('Conditional',    s:hue_3,         '',          '')
-  call <sid>X('Repeat',         s:hue_3,         '',          '')
-  call <sid>X('Label',          s:hue_3,         '',          '')
+  hi! link Function OneHue2
+  hi! link Statement OneHue3
+  hi! link Conditional OneHue3
+  hi! link Repeat OneHue3
+  hi! link Label OneHue3
   call <sid>X('Operator',       s:syntax_accent, '',          'none')
-  call <sid>X('Keyword',        s:hue_5,         '',          '')
-  call <sid>X('Exception',      s:hue_3,         '',          '')
-  call <sid>X('PreProc',        s:hue_6_2,       '',          '')
-  call <sid>X('Include',        s:hue_2,         '',          '')
-  call <sid>X('Define',         s:hue_3,         '',          'none')
-  call <sid>X('Macro',          s:hue_3,         '',          '')
-  call <sid>X('PreCondit',      s:hue_6_2,       '',          '')
-  call <sid>X('Type',           s:hue_6_2,       '',          'none')
-  call <sid>X('StorageClass',   s:hue_6_2,       '',          '')
-  call <sid>X('Structure',      s:hue_6_2,       '',          '')
-  call <sid>X('Typedef',        s:hue_6_2,       '',          '')
-  call <sid>X('Special',        s:hue_2,         '',          '')
+  hi! link Keyword OneHue5
+  hi! link Exception OneHue3
+  hi! link PreProc OneHue62
+  hi! link Include OneHue2
+  hi! link Define OneHue3
+  hi! link Macro OneHue3
+  hi! link PreCondit OneHue62
+  hi! link Type OneHue62
+  hi! link StorageClass OneHue62
+  hi! link Structure OneHue62
+  hi! link Typedef OneHue62
+  hi! link Special OneHue2
   call <sid>X('SpecialChar',    '',              '',          '')
   call <sid>X('Tag',            '',              '',          '')
   call <sid>X('Delimiter',      '',              '',          '')
@@ -440,341 +458,341 @@ if has('gui_running') || has('termguicolors') || &t_Co == 88 || &t_Co == 256
   call <sid>X('Underlined',     '',              '',          'underline')
   call <sid>X('Ignore',         '',              '',          '')
   call <sid>X('Error',          s:hue_5,         s:syntax_bg, 'bold')
-  call <sid>X('Todo',           s:hue_3,         s:syntax_bg, '')
+  hi! link Todo OneHue3
   " }}}
 
   " Diff highlighting -------------------------------------------------------{{{
   call <sid>X('DiffAdd',     s:hue_4, s:visual_grey, '')
   call <sid>X('DiffChange',  s:hue_6, s:visual_grey, '')
   call <sid>X('DiffDelete',  s:hue_5, s:visual_grey, '')
-  call <sid>X('DiffText',    s:hue_2, s:visual_grey, '')
+  hi! link DiffText OneHue2
   call <sid>X('DiffAdded',   s:hue_4, s:visual_grey, '')
   call <sid>X('DiffFile',    s:hue_5, s:visual_grey, '')
   call <sid>X('DiffNewFile', s:hue_4, s:visual_grey, '')
-  call <sid>X('DiffLine',    s:hue_2, s:visual_grey, '')
+  hi! link DiffLine OneHue2
   call <sid>X('DiffRemoved', s:hue_5, s:visual_grey, '')
   " }}}
 
   " Asciidoc highlighting ---------------------------------------------------{{{
-  call <sid>X('asciidocListingBlock',   s:mono_2,  '', '')
+  hi! link asciidocListingBlock OneMono2
   " }}}
 
   " C/C++ highlighting ------------------------------------------------------{{{
-  call <sid>X('cInclude',           s:hue_3,  '', '')
-  call <sid>X('cPreCondit',         s:hue_3,  '', '')
-  call <sid>X('cPreConditMatch',    s:hue_3,  '', '')
+  hi! link cInclude OneHue3
+  hi! link cPreCondit OneHue3
+  hi! link cPreConditMatch OneHue3
 
-  call <sid>X('cType',              s:hue_3,  '', '')
-  call <sid>X('cStorageClass',      s:hue_3,  '', '')
-  call <sid>X('cStructure',         s:hue_3,  '', '')
-  call <sid>X('cOperator',          s:hue_3,  '', '')
-  call <sid>X('cStatement',         s:hue_3,  '', '')
-  call <sid>X('cTODO',              s:hue_3,  '', '')
-  call <sid>X('cConstant',          s:hue_6,  '', '')
-  call <sid>X('cSpecial',           s:hue_1,  '', '')
-  call <sid>X('cSpecialCharacter',  s:hue_1,  '', '')
-  call <sid>X('cString',            s:hue_4,  '', '')
+  hi! link cType OneHue3
+  hi! link cStorageClass OneHue3
+  hi! link cStructure OneHue3
+  hi! link cOperator OneHue3
+  hi! link cStatement OneHue3
+  hi! link cTODO OneHue3
+  hi! link cConstant OneHue6
+  hi! link cSpecial OneHue1
+  hi! link cSpecialCharacter OneHue1
+  hi! link cString OneHue4
 
-  call <sid>X('cppType',            s:hue_3,  '', '')
-  call <sid>X('cppStorageClass',    s:hue_3,  '', '')
-  call <sid>X('cppStructure',       s:hue_3,  '', '')
-  call <sid>X('cppModifier',        s:hue_3,  '', '')
-  call <sid>X('cppOperator',        s:hue_3,  '', '')
-  call <sid>X('cppAccess',          s:hue_3,  '', '')
-  call <sid>X('cppStatement',       s:hue_3,  '', '')
-  call <sid>X('cppConstant',        s:hue_5,  '', '')
-  call <sid>X('cCppString',         s:hue_4,  '', '')
+  hi! link cppType OneHue3
+  hi! link cppStorageClass OneHue3
+  hi! link cppStructure OneHue3
+  hi! link cppModifier OneHue3
+  hi! link cppOperator OneHue3
+  hi! link cppAccess OneHue3
+  hi! link cppStatement OneHue3
+  hi! link cppConstant OneHue5
+  hi! link cCppString OneHue4
   " }}}
 
   " Cucumber highlighting ---------------------------------------------------{{{
-  call <sid>X('cucumberGiven',           s:hue_2,  '', '')
-  call <sid>X('cucumberWhen',            s:hue_2,  '', '')
-  call <sid>X('cucumberWhenAnd',         s:hue_2,  '', '')
-  call <sid>X('cucumberThen',            s:hue_2,  '', '')
-  call <sid>X('cucumberThenAnd',         s:hue_2,  '', '')
-  call <sid>X('cucumberUnparsed',        s:hue_6,  '', '')
+  hi! link cucumberGiven OneHue2
+  hi! link cucumberWhen OneHue2
+  hi! link cucumberWhenAnd OneHue2
+  hi! link cucumberThen OneHue2
+  hi! link cucumberThenAnd OneHue2
+  hi! link cucumberUnparsed OneHue6
   call <sid>X('cucumberFeature',         s:hue_5,  '', 'bold')
-  call <sid>X('cucumberBackground',      s:hue_3,  '', 'bold')
-  call <sid>X('cucumberScenario',        s:hue_3,  '', 'bold')
-  call <sid>X('cucumberScenarioOutline', s:hue_3,  '', 'bold')
+  hi! link cucumberBackground OneHue3
+  hi! link cucumberScenario OneHue3
+  hi! link cucumberScenarioOutline OneHue3
   call <sid>X('cucumberTags',            s:mono_3, '', 'bold')
   call <sid>X('cucumberDelimiter',       s:mono_3, '', 'bold')
   " }}}
 
   " CSS/Sass highlighting ---------------------------------------------------{{{
-  call <sid>X('cssAttrComma',         s:hue_3,  '', '')
-  call <sid>X('cssAttributeSelector', s:hue_4,  '', '')
-  call <sid>X('cssBraces',            s:mono_2, '', '')
-  call <sid>X('cssClassName',         s:hue_6,  '', '')
-  call <sid>X('cssClassNameDot',      s:hue_6,  '', '')
-  call <sid>X('cssDefinition',        s:hue_3,  '', '')
-  call <sid>X('cssFontAttr',          s:hue_6,  '', '')
-  call <sid>X('cssFontDescriptor',    s:hue_3,  '', '')
-  call <sid>X('cssFunctionName',      s:hue_2,  '', '')
-  call <sid>X('cssIdentifier',        s:hue_2,  '', '')
-  call <sid>X('cssImportant',         s:hue_3,  '', '')
-  call <sid>X('cssInclude',           s:mono_1, '', '')
-  call <sid>X('cssIncludeKeyword',    s:hue_3,  '', '')
-  call <sid>X('cssMediaType',         s:hue_6,  '', '')
-  call <sid>X('cssProp',              s:hue_1,  '', '')
-  call <sid>X('cssPseudoClassId',     s:hue_6,  '', '')
-  call <sid>X('cssSelectorOp',        s:hue_3,  '', '')
-  call <sid>X('cssSelectorOp2',       s:hue_3,  '', '')
-  call <sid>X('cssStringQ',           s:hue_4,  '', '')
-  call <sid>X('cssStringQQ',          s:hue_4,  '', '')
-  call <sid>X('cssTagName',           s:hue_5,  '', '')
-  call <sid>X('cssAttr',              s:hue_6,  '', '')
+  hi! link cssAttrComma OneHue3
+  hi! link cssAttributeSelector OneHue4
+  hi! link cssBraces OneMono2
+  hi! link cssClassName OneHue6
+  hi! link cssClassNameDot OneHue6
+  hi! link cssDefinition OneHue3
+  hi! link cssFontAttr OneHue6
+  hi! link cssFontDescriptor OneHue3
+  hi! link cssFunctionName OneHue2
+  hi! link cssIdentifier OneHue2
+  hi! link cssImportant OneHue3
+  hi! link cssInclude OneMono1
+  hi! link cssIncludeKeyword OneHue3
+  hi! link cssMediaType OneHue6
+  hi! link cssProp OneHue1
+  hi! link cssPseudoClassId OneHue6
+  hi! link cssSelectorOp OneHue3
+  hi! link cssSelectorOp2 OneHue3
+  hi! link cssStringQ OneHue4
+  hi! link cssStringQQ OneHue4
+  hi! link cssTagName OneHue5
+  hi! link cssAttr OneHue6
 
-  call <sid>X('sassAmpersand',      s:hue_5,   '', '')
-  call <sid>X('sassClass',          s:hue_6_2, '', '')
-  call <sid>X('sassControl',        s:hue_3,   '', '')
-  call <sid>X('sassExtend',         s:hue_3,   '', '')
-  call <sid>X('sassFor',            s:mono_1,  '', '')
-  call <sid>X('sassProperty',       s:hue_1,   '', '')
-  call <sid>X('sassFunction',       s:hue_1,   '', '')
-  call <sid>X('sassId',             s:hue_2,   '', '')
-  call <sid>X('sassInclude',        s:hue_3,   '', '')
-  call <sid>X('sassMedia',          s:hue_3,   '', '')
-  call <sid>X('sassMediaOperators', s:mono_1,  '', '')
-  call <sid>X('sassMixin',          s:hue_3,   '', '')
-  call <sid>X('sassMixinName',      s:hue_2,   '', '')
-  call <sid>X('sassMixing',         s:hue_3,   '', '')
+  hi! link sassAmpersand OneHue5
+  hi! link sassClass OneHue62
+  hi! link sassControl OneHue3
+  hi! link sassExtend OneHue3
+  hi! link sassFor OneMono1
+  hi! link sassProperty OneHue1
+  hi! link sassFunction OneHue1
+  hi! link sassId OneHue2
+  hi! link sassInclude OneHue3
+  hi! link sassMedia OneHue3
+  hi! link sassMediaOperators OneMono1
+  hi! link sassMixin OneHue3
+  hi! link sassMixinName OneHue2
+  hi! link sassMixing OneHue3
 
-  call <sid>X('scssSelectorName',   s:hue_6_2, '', '')
+  hi! link scssSelectorName OneHue62
   " }}}
 
   " Elixir highlighting------------------------------------------------------{{{
-  hi link elixirModuleDefine Define
-  call <sid>X('elixirAlias',             s:hue_6_2, '', '')
-  call <sid>X('elixirAtom',              s:hue_1,   '', '')
-  call <sid>X('elixirBlockDefinition',   s:hue_3,   '', '')
-  call <sid>X('elixirModuleDeclaration', s:hue_6,   '', '')
-  call <sid>X('elixirInclude',           s:hue_5,   '', '')
-  call <sid>X('elixirOperator',          s:hue_6,   '', '')
+  hi! link elixirModuleDefine Define
+  hi! link elixirAlias OneHue62
+  hi! link elixirAtom OneHue1
+  hi! link elixirBlockDefinition OneHue3
+  hi! link elixirModuleDeclaration OneHue6
+  hi! link elixirInclude OneHue5
+  hi! link elixirOperator OneHue6
   " }}}
 
   " Git and git related plugins highlighting --------------------------------{{{
-  call <sid>X('gitcommitComment',       s:mono_3,  '', '')
-  call <sid>X('gitcommitUnmerged',      s:hue_4,   '', '')
+  hi! link gitcommitComment OneMono3
+  hi! link gitcommitUnmerged OneHue4
   call <sid>X('gitcommitOnBranch',      '',        '', '')
-  call <sid>X('gitcommitBranch',        s:hue_3,   '', '')
-  call <sid>X('gitcommitDiscardedType', s:hue_5,   '', '')
-  call <sid>X('gitcommitSelectedType',  s:hue_4,   '', '')
+  hi! link gitcommitBranch OneHue3
+  hi! link gitcommitDiscardedType OneHue5
+  hi! link gitcommitSelectedType OneHue4
   call <sid>X('gitcommitHeader',        '',        '', '')
-  call <sid>X('gitcommitUntrackedFile', s:hue_1,   '', '')
-  call <sid>X('gitcommitDiscardedFile', s:hue_5,   '', '')
-  call <sid>X('gitcommitSelectedFile',  s:hue_4,   '', '')
-  call <sid>X('gitcommitUnmergedFile',  s:hue_6_2, '', '')
+  hi! link gitcommitUntrackedFile OneHue1
+  hi! link gitcommitDiscardedFile OneHue5
+  hi! link gitcommitSelectedFile OneHue4
+  hi! link gitcommitUnmergedFile OneHue62
   call <sid>X('gitcommitFile',          '',        '', '')
-  hi link gitcommitNoBranch       gitcommitBranch
-  hi link gitcommitUntracked      gitcommitComment
-  hi link gitcommitDiscarded      gitcommitComment
-  hi link gitcommitSelected       gitcommitComment
-  hi link gitcommitDiscardedArrow gitcommitDiscardedFile
-  hi link gitcommitSelectedArrow  gitcommitSelectedFile
-  hi link gitcommitUnmergedArrow  gitcommitUnmergedFile
+  hi! link gitcommitNoBranch       gitcommitBranch
+  hi! link gitcommitUntracked      gitcommitComment
+  hi! link gitcommitDiscarded      gitcommitComment
+  hi! link gitcommitSelected       gitcommitComment
+  hi! link gitcommitDiscardedArrow gitcommitDiscardedFile
+  hi! link gitcommitSelectedArrow  gitcommitSelectedFile
+  hi! link gitcommitUnmergedArrow  gitcommitUnmergedFile
 
-  call <sid>X('SignifySignAdd',    s:hue_4,   '', '')
-  call <sid>X('SignifySignChange', s:hue_6_2, '', '')
-  call <sid>X('SignifySignDelete', s:hue_5,   '', '')
-  hi link GitGutterAdd    SignifySignAdd
-  hi link GitGutterChange SignifySignChange
-  hi link GitGutterDelete SignifySignDelete
-  call <sid>X('diffAdded',         s:hue_4,   '', '')
-  call <sid>X('diffRemoved',       s:hue_5,   '', '')
+  hi! link SignifySignAdd OneHue4
+  hi! link SignifySignChange OneHue62
+  hi! link SignifySignDelete OneHue5
+  hi! link GitGutterAdd    SignifySignAdd
+  hi! link GitGutterChange SignifySignChange
+  hi! link GitGutterDelete SignifySignDelete
+  hi! link diffAdded OneHue4
+  hi! link diffRemoved OneHue5
   " }}}
 
   " Go highlighting ---------------------------------------------------------{{{
-  call <sid>X('goDeclaration',         s:hue_3, '', '')
-  call <sid>X('goField',               s:hue_5, '', '')
-  call <sid>X('goMethod',              s:hue_1, '', '')
-  call <sid>X('goType',                s:hue_3, '', '')
-  call <sid>X('goUnsignedInts',        s:hue_1, '', '')
+  hi! link goDeclaration OneHue3
+  hi! link goField OneHue5
+  hi! link goMethod OneHue1
+  hi! link goType OneHue3
+  hi! link goUnsignedInts OneHue1
   " }}}
 
   " Haskell highlighting ----------------------------------------------------{{{
-  call <sid>X('haskellDeclKeyword',    s:hue_2, '', '')
-  call <sid>X('haskellType',           s:hue_4, '', '')
-  call <sid>X('haskellWhere',          s:hue_5, '', '')
-  call <sid>X('haskellImportKeywords', s:hue_2, '', '')
-  call <sid>X('haskellOperators',      s:hue_5, '', '')
-  call <sid>X('haskellDelimiter',      s:hue_2, '', '')
-  call <sid>X('haskellIdentifier',     s:hue_6, '', '')
-  call <sid>X('haskellKeyword',        s:hue_5, '', '')
-  call <sid>X('haskellNumber',         s:hue_1, '', '')
-  call <sid>X('haskellString',         s:hue_1, '', '')
+  hi! link haskellDeclKeyword OneHue2
+  hi! link haskellType OneHue4
+  hi! link haskellWhere OneHue5
+  hi! link haskellImportKeywords OneHue2
+  hi! link haskellOperators OneHue5
+  hi! link haskellDelimiter OneHue2
+  hi! link haskellIdentifier OneHue6
+  hi! link haskellKeyword OneHue5
+  hi! link haskellNumber OneHue1
+  hi! link haskellString OneHue1
   "}}}
 
   " HTML highlighting -------------------------------------------------------{{{
-  call <sid>X('htmlArg',            s:hue_6,  '', '')
-  call <sid>X('htmlTagName',        s:hue_5,  '', '')
-  call <sid>X('htmlTagN',           s:hue_5,  '', '')
-  call <sid>X('htmlSpecialTagName', s:hue_5,  '', '')
-  call <sid>X('htmlTag',            s:mono_2, '', '')
-  call <sid>X('htmlEndTag',         s:mono_2, '', '')
+  hi! link htmlArg OneHue6
+  hi! link htmlTagName OneHue5
+  hi! link htmlTagN OneHue5
+  hi! link htmlSpecialTagName OneHue5
+  hi! link htmlTag OneMono2
+  hi! link htmlEndTag OneMono2
 
   call <sid>X('MatchTag', s:hue_5, s:syntax_cursor, 'underline,bold')
   " }}}
 
   " JavaScript highlighting -------------------------------------------------{{{
-  call <sid>X('coffeeString',           s:hue_4,   '', '')
+  hi! link coffeeString OneHue4
 
-  call <sid>X('javaScriptBraces',       s:mono_2,  '', '')
-  call <sid>X('javaScriptFunction',     s:hue_3,   '', '')
-  call <sid>X('javaScriptIdentifier',   s:hue_3,   '', '')
-  call <sid>X('javaScriptNull',         s:hue_6,   '', '')
-  call <sid>X('javaScriptNumber',       s:hue_6,   '', '')
-  call <sid>X('javaScriptRequire',      s:hue_1,   '', '')
-  call <sid>X('javaScriptReserved',     s:hue_3,   '', '')
+  hi! link javaScriptBraces OneMono2
+  hi! link javaScriptFunction OneHue3
+  hi! link javaScriptIdentifier OneHue3
+  hi! link javaScriptNull OneHue6
+  hi! link javaScriptNumber OneHue6
+  hi! link javaScriptRequire OneHue1
+  hi! link javaScriptReserved OneHue3
   " https://github.com/pangloss/vim-javascript
-  call <sid>X('jsArrowFunction',        s:hue_3,   '', '')
-  call <sid>X('jsBraces',               s:mono_2,  '', '')
-  call <sid>X('jsClassBraces',          s:mono_2,  '', '')
-  call <sid>X('jsClassKeywords',        s:hue_3,   '', '')
-  call <sid>X('jsDocParam',             s:hue_2,   '', '')
-  call <sid>X('jsDocTags',              s:hue_3,   '', '')
-  call <sid>X('jsFuncBraces',           s:mono_2,  '', '')
-  call <sid>X('jsFuncCall',             s:hue_2,   '', '')
-  call <sid>X('jsFuncParens',           s:mono_2,  '', '')
-  call <sid>X('jsFunction',             s:hue_3,   '', '')
-  call <sid>X('jsGlobalObjects',        s:hue_6_2, '', '')
-  call <sid>X('jsModuleWords',          s:hue_3,   '', '')
-  call <sid>X('jsModules',              s:hue_3,   '', '')
-  call <sid>X('jsNoise',                s:mono_2,  '', '')
-  call <sid>X('jsNull',                 s:hue_6,   '', '')
-  call <sid>X('jsOperator',             s:hue_3,   '', '')
-  call <sid>X('jsParens',               s:mono_2,  '', '')
-  call <sid>X('jsStorageClass',         s:hue_3,   '', '')
-  call <sid>X('jsTemplateBraces',       s:hue_5_2, '', '')
-  call <sid>X('jsTemplateVar',          s:hue_4,   '', '')
-  call <sid>X('jsThis',                 s:hue_5,   '', '')
-  call <sid>X('jsUndefined',            s:hue_6,   '', '')
-  call <sid>X('jsObjectValue',          s:hue_2,   '', '')
-  call <sid>X('jsObjectKey',            s:hue_1,   '', '')
-  call <sid>X('jsReturn',               s:hue_3,   '', '')
+  hi! link jsArrowFunction OneHue3
+  hi! link jsBraces OneMono2
+  hi! link jsClassBraces OneMono2
+  hi! link jsClassKeywords OneHue3
+  hi! link jsDocParam OneHue2
+  hi! link jsDocTags OneHue3
+  hi! link jsFuncBraces OneMono2
+  hi! link jsFuncCall OneHue2
+  hi! link jsFuncParens OneMono2
+  hi! link jsFunction OneHue3
+  hi! link jsGlobalObjects OneHue62
+  hi! link jsModuleWords OneHue3
+  hi! link jsModules OneHue3
+  hi! link jsNoise OneMono2
+  hi! link jsNull OneHue6
+  hi! link jsOperator OneHue3
+  hi! link jsParens OneMono2
+  hi! link jsStorageClass OneHue3
+  hi! link jsTemplateBraces OneHue52
+  hi! link jsTemplateVar OneHue4
+  hi! link jsThis OneHue5
+  hi! link jsUndefined OneHue6
+  hi! link jsObjectValue OneHue2
+  hi! link jsObjectKey OneHue1
+  hi! link jsReturn OneHue3
   " https://github.com/othree/yajs.vim
-  call <sid>X('javascriptArrowFunc',    s:hue_3,   '', '')
-  call <sid>X('javascriptClassExtends', s:hue_3,   '', '')
-  call <sid>X('javascriptClassKeyword', s:hue_3,   '', '')
-  call <sid>X('javascriptDocNotation',  s:hue_3,   '', '')
-  call <sid>X('javascriptDocParamName', s:hue_2,   '', '')
-  call <sid>X('javascriptDocTags',      s:hue_3,   '', '')
-  call <sid>X('javascriptEndColons',    s:mono_3,  '', '')
-  call <sid>X('javascriptExport',       s:hue_3,   '', '')
-  call <sid>X('javascriptFuncArg',      s:mono_1,  '', '')
-  call <sid>X('javascriptFuncKeyword',  s:hue_3,   '', '')
-  call <sid>X('javascriptIdentifier',   s:hue_5,   '', '')
-  call <sid>X('javascriptImport',       s:hue_3,   '', '')
-  call <sid>X('javascriptObjectLabel',  s:mono_1,  '', '')
-  call <sid>X('javascriptOpSymbol',     s:hue_1,   '', '')
-  call <sid>X('javascriptOpSymbols',    s:hue_1,   '', '')
-  call <sid>X('javascriptPropertyName', s:hue_4,   '', '')
-  call <sid>X('javascriptTemplateSB',   s:hue_5_2, '', '')
-  call <sid>X('javascriptVariable',     s:hue_3,   '', '')
+  hi! link javascriptArrowFunc OneHue3
+  hi! link javascriptClassExtends OneHue3
+  hi! link javascriptClassKeyword OneHue3
+  hi! link javascriptDocNotation OneHue3
+  hi! link javascriptDocParamName OneHue2
+  hi! link javascriptDocTags OneHue3
+  hi! link javascriptEndColons OneMono3
+  hi! link javascriptExport OneHue3
+  hi! link javascriptFuncArg OneMono1
+  hi! link javascriptFuncKeyword OneHue3
+  hi! link javascriptIdentifier OneHue5
+  hi! link javascriptImport OneHue3
+  hi! link javascriptObjectLabel OneMono1
+  hi! link javascriptOpSymbol OneHue1
+  hi! link javascriptOpSymbols OneHue1
+  hi! link javascriptPropertyName OneHue4
+  hi! link javascriptTemplateSB OneHue52
+  hi! link javascriptVariable OneHue3
   " }}}
 
   " JSON highlighting -------------------------------------------------------{{{
-  call <sid>X('jsonCommentError',         s:mono_1,  '', ''        )
-  call <sid>X('jsonKeyword',              s:hue_5,   '', ''        )
-  call <sid>X('jsonQuote',                s:mono_3,  '', ''        )
+  hi! link jsonCommentError OneMono1
+  hi! link jsonKeyword OneHue5
+  hi! link jsonQuote OneMono3
   call <sid>X('jsonTrailingCommaError',   s:hue_5,   '', 'reverse' )
   call <sid>X('jsonMissingCommaError',    s:hue_5,   '', 'reverse' )
   call <sid>X('jsonNoQuotesError',        s:hue_5,   '', 'reverse' )
   call <sid>X('jsonNumError',             s:hue_5,   '', 'reverse' )
-  call <sid>X('jsonString',               s:hue_4,   '', ''        )
-  call <sid>X('jsonBoolean',              s:hue_3,   '', ''        )
-  call <sid>X('jsonNumber',               s:hue_6,   '', ''        )
+  hi! link jsonString OneHue4
+  hi! link jsonBoolean OneHue3
+  hi! link jsonNumber OneHue6
   call <sid>X('jsonStringSQError',        s:hue_5,   '', 'reverse' )
   call <sid>X('jsonSemicolonError',       s:hue_5,   '', 'reverse' )
   " }}}
 
   " Markdown highlighting ---------------------------------------------------{{{
-  call <sid>X('markdownUrl',              s:mono_3,  '', '')
+  hi! link markdownUrl OneMono3
   call <sid>X('markdownBold',             s:hue_6,   '', 'bold')
   call <sid>X('markdownItalic',           s:hue_6,   '', 'bold')
-  call <sid>X('markdownCode',             s:hue_4,   '', '')
-  call <sid>X('markdownCodeBlock',        s:hue_5,   '', '')
-  call <sid>X('markdownCodeDelimiter',    s:hue_4,   '', '')
-  call <sid>X('markdownHeadingDelimiter', s:hue_5_2, '', '')
-  call <sid>X('markdownH1',               s:hue_5,   '', '')
-  call <sid>X('markdownH2',               s:hue_5,   '', '')
-  call <sid>X('markdownH3',               s:hue_5,   '', '')
-  call <sid>X('markdownH3',               s:hue_5,   '', '')
-  call <sid>X('markdownH4',               s:hue_5,   '', '')
-  call <sid>X('markdownH5',               s:hue_5,   '', '')
-  call <sid>X('markdownH6',               s:hue_5,   '', '')
-  call <sid>X('markdownListMarker',       s:hue_5,   '', '')
+  hi! link markdownCode OneHue4
+  hi! link markdownCodeBlock OneHue5
+  hi! link markdownCodeDelimiter OneHue4
+  hi! link markdownHeadingDelimiter OneHue52
+  hi! link markdownH1 OneHue5
+  hi! link markdownH2 OneHue5
+  hi! link markdownH3 OneHue5
+  hi! link markdownH3 OneHue5
+  hi! link markdownH4 OneHue5
+  hi! link markdownH5 OneHue5
+  hi! link markdownH6 OneHue5
+  hi! link markdownListMarker OneHue5
   " }}}
 
   " PHP highlighting --------------------------------------------------------{{{
-  call <sid>X('phpClass',        s:hue_6_2, '', '')
-  call <sid>X('phpFunction',     s:hue_2,   '', '')
-  call <sid>X('phpFunctions',    s:hue_2,   '', '')
-  call <sid>X('phpInclude',      s:hue_3,   '', '')
-  call <sid>X('phpKeyword',      s:hue_3,   '', '')
-  call <sid>X('phpParent',       s:mono_3,  '', '')
-  call <sid>X('phpType',         s:hue_3,   '', '')
-  call <sid>X('phpSuperGlobals', s:hue_5,   '', '')
+  hi! link phpClass OneHue62
+  hi! link phpFunction OneHue2
+  hi! link phpFunctions OneHue2
+  hi! link phpInclude OneHue3
+  hi! link phpKeyword OneHue3
+  hi! link phpParent OneMono3
+  hi! link phpType OneHue3
+  hi! link phpSuperGlobals OneHue5
   " }}}
 
   " Pug (Formerly Jade) highlighting ----------------------------------------{{{
-  call <sid>X('pugAttributesDelimiter',   s:hue_6,    '', '')
-  call <sid>X('pugClass',                 s:hue_6,    '', '')
+  hi! link pugAttributesDelimiter OneHue6
+  hi! link pugClass OneHue6
   call <sid>X('pugDocType',               s:mono_3,   '', s:italic)
-  call <sid>X('pugTag',                   s:hue_5,    '', '')
+  hi! link pugTag OneHue5
   " }}}
 
   " PureScript highlighting -------------------------------------------------{{{
-  call <sid>X('purescriptKeyword',          s:hue_3,     '', '')
-  call <sid>X('purescriptModuleName',       s:syntax_fg, '', '')
-  call <sid>X('purescriptIdentifier',       s:syntax_fg, '', '')
-  call <sid>X('purescriptType',             s:hue_6_2,   '', '')
-  call <sid>X('purescriptTypeVar',          s:hue_5,     '', '')
-  call <sid>X('purescriptConstructor',      s:hue_5,     '', '')
-  call <sid>X('purescriptOperator',         s:syntax_fg, '', '')
+  hi! link purescriptKeyword OneHue3
+  hi! link purescriptModuleName OneSyntaxFg
+  hi! link purescriptIdentifier OneSyntaxFg
+  hi! link purescriptType OneHue62
+  hi! link purescriptTypeVar OneHue5
+  hi! link purescriptConstructor OneHue5
+  hi! link purescriptOperator OneSyntaxFg
   " }}}
 
   " Python highlighting -----------------------------------------------------{{{
-  call <sid>X('pythonImport',               s:hue_3,     '', '')
-  call <sid>X('pythonBuiltin',              s:hue_1,     '', '')
-  call <sid>X('pythonStatement',            s:hue_3,     '', '')
-  call <sid>X('pythonParam',                s:hue_6,     '', '')
-  call <sid>X('pythonEscape',               s:hue_5,     '', '')
+  hi! link pythonImport OneHue3
+  hi! link pythonBuiltin OneHue1
+  hi! link pythonStatement OneHue3
+  hi! link pythonParam OneHue6
+  hi! link pythonEscape OneHue5
   call <sid>X('pythonSelf',                 s:mono_2,    '', s:italic)
-  call <sid>X('pythonClass',                s:hue_2,     '', '')
-  call <sid>X('pythonOperator',             s:hue_3,     '', '')
-  call <sid>X('pythonEscape',               s:hue_5,     '', '')
-  call <sid>X('pythonFunction',             s:hue_2,     '', '')
-  call <sid>X('pythonKeyword',              s:hue_2,     '', '')
-  call <sid>X('pythonModule',               s:hue_3,     '', '')
-  call <sid>X('pythonStringDelimiter',      s:hue_4,     '', '')
-  call <sid>X('pythonSymbol',               s:hue_1,     '', '')
+  hi! link pythonClass OneHue2
+  hi! link pythonOperator OneHue3
+  hi! link pythonEscape OneHue5
+  hi! link pythonFunction OneHue2
+  hi! link pythonKeyword OneHue2
+  hi! link pythonModule OneHue3
+  hi! link pythonStringDelimiter OneHue4
+  hi! link pythonSymbol OneHue1
   " }}}
 
   " Ruby highlighting -------------------------------------------------------{{{
-  call <sid>X('rubyBlock',                     s:hue_3,   '', '')
-  call <sid>X('rubyBlockParameter',            s:hue_5,   '', '')
-  call <sid>X('rubyBlockParameterList',        s:hue_5,   '', '')
-  call <sid>X('rubyCapitalizedMethod',         s:hue_3,   '', '')
-  call <sid>X('rubyClass',                     s:hue_3,   '', '')
-  call <sid>X('rubyConstant',                  s:hue_6_2, '', '')
-  call <sid>X('rubyControl',                   s:hue_3,   '', '')
-  call <sid>X('rubyDefine',                    s:hue_3,   '', '')
-  call <sid>X('rubyEscape',                    s:hue_5,   '', '')
-  call <sid>X('rubyFunction',                  s:hue_2,   '', '')
-  call <sid>X('rubyGlobalVariable',            s:hue_5,   '', '')
-  call <sid>X('rubyInclude',                   s:hue_2,   '', '')
-  call <sid>X('rubyIncluderubyGlobalVariable', s:hue_5,   '', '')
-  call <sid>X('rubyInstanceVariable',          s:hue_5,   '', '')
-  call <sid>X('rubyInterpolation',             s:hue_1,   '', '')
-  call <sid>X('rubyInterpolationDelimiter',    s:hue_5,   '', '')
-  call <sid>X('rubyKeyword',                   s:hue_2,   '', '')
-  call <sid>X('rubyModule',                    s:hue_3,   '', '')
-  call <sid>X('rubyPseudoVariable',            s:hue_5,   '', '')
-  call <sid>X('rubyRegexp',                    s:hue_1,   '', '')
-  call <sid>X('rubyRegexpDelimiter',           s:hue_1,   '', '')
-  call <sid>X('rubyStringDelimiter',           s:hue_4,   '', '')
-  call <sid>X('rubySymbol',                    s:hue_1,   '', '')
+  hi! link rubyBlock OneHue3
+  hi! link rubyBlockParameter OneHue5
+  hi! link rubyBlockParameterList OneHue5
+  hi! link rubyCapitalizedMethod OneHue3
+  hi! link rubyClass OneHue3
+  hi! link rubyConstant OneHue62
+  hi! link rubyControl OneHue3
+  hi! link rubyDefine OneHue3
+  hi! link rubyEscape OneHue5
+  hi! link rubyFunction OneHue2
+  hi! link rubyGlobalVariable OneHue5
+  hi! link rubyInclude OneHue2
+  hi! link rubyIncluderubyGlobalVariable OneHue5
+  hi! link rubyInstanceVariable OneHue5
+  hi! link rubyInterpolation OneHue1
+  hi! link rubyInterpolationDelimiter OneHue5
+  hi! link rubyKeyword OneHue2
+  hi! link rubyModule OneHue3
+  hi! link rubyPseudoVariable OneHue5
+  hi! link rubyRegexp OneHue1
+  hi! link rubyRegexpDelimiter OneHue1
+  hi! link rubyStringDelimiter OneHue4
+  hi! link rubySymbol OneHue1
   " }}}
 
   " Spelling highlighting ---------------------------------------------------{{{
@@ -785,61 +803,61 @@ if has('gui_running') || has('termguicolors') || &t_Co == 88 || &t_Co == 256
   " }}}
 
   " Vim highlighting --------------------------------------------------------{{{
-  call <sid>X('vimCommand',      s:hue_3,  '', '')
+  hi! link vimCommand OneHue3
   call <sid>X('vimCommentTitle', s:mono_3, '', 'bold')
-  call <sid>X('vimFunction',     s:hue_1,  '', '')
-  call <sid>X('vimFuncName',     s:hue_3,  '', '')
-  call <sid>X('vimHighlight',    s:hue_2,  '', '')
+  hi! link vimFunction OneHue1
+  hi! link vimFuncName OneHue3
+  hi! link vimHighlight OneHue2
   call <sid>X('vimLineComment',  s:mono_3, '', s:italic)
-  call <sid>X('vimParenSep',     s:mono_2, '', '')
-  call <sid>X('vimSep',          s:mono_2, '', '')
-  call <sid>X('vimUserFunc',     s:hue_1,  '', '')
-  call <sid>X('vimVar',          s:hue_5,  '', '')
+  hi! link vimParenSep OneMono2
+  hi! link vimSep OneMono2
+  hi! link vimUserFunc OneHue1
+  hi! link vimVar OneHue5
   " }}}
 
   " XML highlighting --------------------------------------------------------{{{
-  call <sid>X('xmlAttrib',  s:hue_6_2, '', '')
-  call <sid>X('xmlEndTag',  s:hue_5,   '', '')
-  call <sid>X('xmlTag',     s:hue_5,   '', '')
-  call <sid>X('xmlTagName', s:hue_5,   '', '')
+  hi! link xmlAttrib OneHue62
+  hi! link xmlEndTag OneHue5
+  hi! link xmlTag OneHue5
+  hi! link xmlTagName OneHue5
   " }}}
 
   " ZSH highlighting --------------------------------------------------------{{{
-  call <sid>X('zshCommands',     s:syntax_fg, '', '')
-  call <sid>X('zshDeref',        s:hue_5,     '', '')
-  call <sid>X('zshShortDeref',   s:hue_5,     '', '')
-  call <sid>X('zshFunction',     s:hue_1,     '', '')
-  call <sid>X('zshKeyword',      s:hue_3,     '', '')
-  call <sid>X('zshSubst',        s:hue_5,     '', '')
-  call <sid>X('zshSubstDelim',   s:mono_3,    '', '')
-  call <sid>X('zshTypes',        s:hue_3,     '', '')
-  call <sid>X('zshVariableDef',  s:hue_6,     '', '')
+  hi! link zshCommands OneSyntaxFg
+  hi! link zshDeref OneHue5
+  hi! link zshShortDeref OneHue5
+  hi! link zshFunction OneHue1
+  hi! link zshKeyword OneHue3
+  hi! link zshSubst OneHue5
+  hi! link zshSubstDelim OneMono3
+  hi! link zshTypes OneHue3
+  hi! link zshVariableDef OneHue6
   " }}}
 
   " Rust highlighting -------------------------------------------------------{{{
   call <sid>X('rustExternCrate',          s:hue_5,    '', 'bold')
-  call <sid>X('rustIdentifier',           s:hue_2,    '', '')
-  call <sid>X('rustDeriveTrait',          s:hue_4,    '', '')
-  call <sid>X('SpecialComment',           s:mono_3,    '', '')
-  call <sid>X('rustCommentLine',          s:mono_3,    '', '')
-  call <sid>X('rustCommentLineDoc',       s:mono_3,    '', '')
-  call <sid>X('rustCommentLineDocError',  s:mono_3,    '', '')
-  call <sid>X('rustCommentBlock',         s:mono_3,    '', '')
-  call <sid>X('rustCommentBlockDoc',      s:mono_3,    '', '')
-  call <sid>X('rustCommentBlockDocError', s:mono_3,    '', '')
+  hi! link rustIdentifier OneHue2
+  hi! link rustDeriveTrait OneHue4
+  hi! link SpecialComment OneMono3
+  hi! link rustCommentLine OneMono3
+  hi! link rustCommentLineDoc OneMono3
+  hi! link rustCommentLineDocError OneMono3
+  hi! link rustCommentBlock OneMono3
+  hi! link rustCommentBlockDoc OneMono3
+  hi! link rustCommentBlockDocError OneMono3
   " }}}
 
   " man highlighting --------------------------------------------------------{{{
-  hi link manTitle String
-  call <sid>X('manFooter', s:mono_3, '', '')
+  hi! link manTitle String
+  hi! link manFooter OneMono3
   " }}}
 
   " ALE (Asynchronous Lint Engine) highlighting -----------------------------{{{
-  call <sid>X('ALEWarningSign', s:hue_6_2, '', '')
-  call <sid>X('ALEErrorSign', s:hue_5,   '', '')
+  hi! link ALEWarningSign OneHue62
+  hi! link ALEErrorSign OneHue5
 
 
-   " Neovim NERDTree Background fix ------------------------------------------{{{
+  " Neovim NERDTree Background fix ------------------------------------------{{{
   call <sid>X('NERDTreeFile', s:syntax_fg, '', '')
   " }}}
 


### PR DESCRIPTION
`hi link` reduces loading time from `33.6` ms to `18.3` ms. This idea is borrowed from vim theme [gruvbox](https://github.com/morhetz/gruvbox/blob/master/colors/gruvbox.vim).

Force link `hi! link` is needed to override default settings,
otherwise warning messages will be popped up during theme loading.


```bash
vim-one  predefined-groups
❯ vim-profiler -r 10 nvim
# omitted
=====================================
Top 10 plugins slowing nvim's startup
=====================================
1        18.253   vim-one
2         6.301   vim-airline
3         6.112   coc.nvim
4         3.811   vim-polyglot
5         2.738   colorizer
6         2.405   vim-textobj-comment
7         2.358   vim-textobj-xmlattr
8         1.691   vim-sensible
9         1.691   vim-textobj-line
10        1.285   ctrlp.vim
=====================================
```