### PR TITLE
Correcting indentation on README for readability purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ To benefit from the **true color** support make sure to add the following lines 
 "(see < http://sunaku.github.io/tmux-24bit-color.html#usage > for more information.)
 if (empty($TMUX))
   if (has("nvim"))
-  "For Neovim 0.1.3 and 0.1.4 < https://github.com/neovim/neovim/pull/2198 >
-  let $NVIM_TUI_ENABLE_TRUE_COLOR=1
+    "For Neovim 0.1.3 and 0.1.4 < https://github.com/neovim/neovim/pull/2198 >
+    let $NVIM_TUI_ENABLE_TRUE_COLOR=1
   endif
   "For Neovim > 0.1.5 and Vim > patch 7.4.1799 < https://github.com/vim/vim/commit/61be73bb0f965a895bfb064ea3e55476ac175162 >
   "Based on Vim patch 7.4.1770 (`guicolors` option) < https://github.com/vim/vim/commit/8a633e3427b47286869aa4b96f2bfc1fe65b25cd >


### PR DESCRIPTION
Hey all, first contribution to your all's repo!

I was going through the setup/install notes on my machine and copy & pasted a code block in the README to enable `true color`. Following this I had an issue preventing my .vimrc from being loaded properly. Due this I grokked my changes until ultimately getting stuck looking at the non-indented conditional for far too long (I felt like something looked wrong but couldn't figure out what it was haha).

Anyways this definitely wasn't meant to be nitpicky so I really hope you all would consider merging these changes.

Thanks!