### PR TITLE
Remove hardcoded terminal colors

### DIFF
--- a/colors/one.vim
+++ b/colors/one.vim
@@ -843,26 +843,6 @@ if has('gui_running') || has('termguicolors') || &t_Co == 88 || &t_Co == 256
   call <sid>X('NERDTreeFile', s:syntax_fg, '', '')
   " }}}
 
-  " Neovim Terminal Colors --------------------------------------------------{{{
-  if has('nvim')
-    let g:terminal_color_0  = "#353a44"
-    let g:terminal_color_8  = "#353a44"
-    let g:terminal_color_1  = "#e88388"
-    let g:terminal_color_9  = "#e88388"
-    let g:terminal_color_2  = "#a7cc8c"
-    let g:terminal_color_10 = "#a7cc8c"
-    let g:terminal_color_3  = "#ebca8d"
-    let g:terminal_color_11 = "#ebca8d"
-    let g:terminal_color_4  = "#72bef2"
-    let g:terminal_color_12 = "#72bef2"
-    let g:terminal_color_5  = "#d291e4"
-    let g:terminal_color_13 = "#d291e4"
-    let g:terminal_color_6  = "#65c2cd"
-    let g:terminal_color_14 = "#65c2cd"
-    let g:terminal_color_7  = "#e3e5e9"
-    let g:terminal_color_15 = "#e3e5e9"
-  endif
-
   " Delete functions =========================================================={{{
   " delf <SID>X
   " delf <SID>XAPI


### PR DESCRIPTION
With this PR https://github.com/neovim/neovim/pull/10994, it is no longer necessary to hard code terminal colors for base 16 and neovim will handle it correctly. This PR has been merged and will be available in the next release of neovim.

I ran into this issue because I was using the light theme, and the terminal colors hardcoded here appear to correspond to the dark theme. With the `one` light theme, the terminal colors do not match that of a terminal outside neovim.
For an immediate fix to work with a stable version of neovim, you can hard code values for both light and dark theme separately. 