### PR TITLE
Define colors for the integrated terminal

### DIFF
--- a/colors/one.vim
+++ b/colors/one.vim
@@ -854,6 +854,31 @@ if has('gui_running') || has('termguicolors') || &t_Co == 88 || &t_Co == 256
   call <sid>X('NERDTreeFile', s:syntax_fg, '', '')
   " }}}
 
+
+  " Integrated terminal colors ----------------------------------------------{{{
+  if has('terminal')
+    let g:terminal_ansi_colors = [
+          \ s:syntax_bg[0],
+          \ s:hue_5[0],
+          \ s:hue_4[0],
+          \ s:hue_6_2[0],
+          \ s:hue_2[0],
+          \ s:hue_3[0],
+          \ s:hue_1[0],
+          \ s:mono_2[0],
+          \ s:mono_3[0],
+          \ s:hue_5[0],
+          \ s:hue_4[0],
+          \ s:hue_6_2[0],
+          \ s:hue_2[0],
+          \ s:hue_3[0],
+          \ s:hue_1[0],
+          \ s:syntax_fg[0],
+          \]
+  endif
+  " }}}
+
+
   " Delete functions =========================================================={{{
   " delf <SID>X
   " delf <SID>XAPI


### PR DESCRIPTION
This sets the 16 default colors within the Vim 8 integrated terminal (via `g:terminal_ansi_colors`) so that terminal apps look as expected. The colors are in terms of the already-defined variables, so it should stay consistent and work in light mode too.

Here's a comparison with <q>One Half Dark</q> from Windows Terminal. Note that WT decided to use a very bright color for white, but I've chosen to stick with the colorscheme so it looks better next to actual editor buffers.

![Comparison with Windows Terminal's "One Half Dark"](https://user-images.githubusercontent.com/2198220/109384195-fa55eb00-789f-11eb-9102-9253c1e4dbab.png)