### PR TITLE
Stay compatible with Neovim >= 0.10

### DIFF
--- a/colors/one.vim
+++ b/colors/one.vim
@@ -19,6 +19,9 @@ if exists("*<SID>X")
 endif
 
 hi clear
+if has('nvim-0.10')
+  runtime colors/vim.lua
+endif
 syntax reset
 if exists('g:colors_name')
   unlet g:colors_name


### PR DESCRIPTION
Neovim 0.10 changes the default color scheme and others highlighting groups different from Vim. Therefore, source the old vim colorscheme before vim.one defines any highlights. See
<https://github.com/neovim/neovim/issues/26378> for more information.

This PR fixes issue #129.